### PR TITLE
Remove deprecated function JString

### DIFF
--- a/models/phocadownloadcat.php
+++ b/models/phocadownloadcat.php
@@ -8,6 +8,7 @@
  */
 defined( '_JEXEC' ) or die();
 jimport('joomla.application.component.modeladmin');
+use Joomla\String\StringHelper;
 
 class PhocaDownloadCpModelPhocaDownloadCat extends JModelAdmin
 {
@@ -616,8 +617,8 @@ class PhocaDownloadCpModelPhocaDownloadCat extends JModelAdmin
 		$table = $this->getTable();
 		while ($table->load(array('alias' => $alias, 'parent_id' => $category_id)))
 		{
-			$title = JString::increment($title);
-			$alias = JString::increment($alias, 'dash');
+			$title = StringHelper::increment($title);
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/models/phocadownloadlinkfile.php
+++ b/models/phocadownloadlinkfile.php
@@ -10,6 +10,7 @@
  */
 defined('_JEXEC') or die();
 jimport('joomla.application.component.model');
+use Joomla\String\StringHelper;
 
 class PhocaDownloadCpModelPhocaDownloadLinkFile extends JModelLegacy
 {
@@ -93,7 +94,7 @@ class PhocaDownloadCpModelPhocaDownloadLinkFile extends JModelLegacy
 		$filter_order		= $app->getUserStateFromRequest( $this->_context.'.filter_order',	'filter_order',	'a.ordering',	'cmd' );
 		$filter_order_Dir	= $app->getUserStateFromRequest( $this->_context.'.filter_order_Dir',	'filter_order_Dir',	'',	'word' );
 		$search				= $app->getUserStateFromRequest( $this->_context.'.search','search','','string' );
-		$search				= JString::strtolower( $search );
+		$search				= StringHelper::strtolower( $search );
 
 		$where = array();
 

--- a/site/models/phocadownloadlinkfile.php
+++ b/site/models/phocadownloadlinkfile.php
@@ -10,6 +10,7 @@
  */
 defined('_JEXEC') or die();
 jimport('joomla.application.component.model');
+use Joomla\String\StringHelper;
 
 // CUSTOM PAGINATON
 class PhocaDownloadViewPhocaDownloadLinkFilePagination extends JPagination
@@ -184,7 +185,7 @@ class PhocaDownloadModelPhocaDownloadLinkFile extends JModelLegacy
 		$filter_order		= $app->getUserStateFromRequest( $this->_context.'.filter_order',	'filter_order',	'a.ordering',	'cmd' );
 		$filter_order_Dir	= $app->getUserStateFromRequest( $this->_context.'.filter_order_Dir',	'filter_order_Dir',	'',	'word' );
 		$search				= $app->getUserStateFromRequest( $this->_context.'.search','search','','string' );
-		$search				= JString::strtolower( $search );
+		$search				= StringHelper::strtolower( $search );
 
 		$where = array();
 

--- a/site/models/user.php
+++ b/site/models/user.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die();
 jimport('joomla.application.component.model');
 jimport( 'joomla.filesystem.folder' ); 
 jimport( 'joomla.filesystem.file' );
+use Joomla\String\StringHelper;
 
 class PhocaDownloadModelUser extends JModelLegacy
 {
@@ -96,7 +97,7 @@ class PhocaDownloadModelUser extends JModelLegacy
 		$filter_order		= $app->getUserStateFromRequest( $this->_context_files.'.filter_order','filter_order','a.ordering','cmd' );
 		$filter_order_Dir	= $app->getUserStateFromRequest( $this->_context_files.'.filter_order_Dir','filter_order_Dir_files',	'', 'word' );
 		$search				= $app->getUserStateFromRequest( $this->_context_files.'.search', 'search', '', 'string' );
-		$search				= JString::strtolower( $search );
+		$search				= StringHelper::strtolower( $search );
 		
 		$where = array();
 		

--- a/site/views/phocadownloadlinkfile/view.html.php
+++ b/site/views/phocadownloadlinkfile/view.html.php
@@ -10,6 +10,7 @@
  */
 defined('_JEXEC') or die();
 jimport( 'joomla.application.component.view' );
+use Joomla\String\StringHelper;
  
 class PhocaDownloadViewPhocaDownloadLinkFile extends JViewLegacy
 {
@@ -55,7 +56,7 @@ class PhocaDownloadViewPhocaDownloadLinkFile extends JViewLegacy
 		$filter_order		= $app->getUserStateFromRequest( $this->_context.'.filter_order',	'filter_order',		'a.ordering', 'cmd' );
 		$filter_order_Dir	= $app->getUserStateFromRequest( $this->_context.'.filter_order_Dir',	'filter_order_Dir',	'', 'word' );
 		$search				= $app->getUserStateFromRequest( $this->_context.'.search','search', '', 'string' );
-		$search				= JString::strtolower( $search );
+		$search				= StringHelper::strtolower( $search );
 
 		// Get data from the model
 		$items		=  $this->get( 'Data');

--- a/site/views/user/view.html.php
+++ b/site/views/user/view.html.php
@@ -10,7 +10,7 @@ defined( '_JEXEC' ) or die();
 jimport( 'joomla.client.helper' );
 jimport( 'joomla.application.component.view' );
 jimport( 'joomla.html.pane' );
-
+use Joomla\String\StringHelper;
 
 class PhocaDownloadViewUser extends JViewLegacy
 {
@@ -207,7 +207,7 @@ class PhocaDownloadViewUser extends JViewLegacy
 		$filter_order_files		= $app->getUserStateFromRequest( $this->_context_files.'.filter_order','filter_order','a.ordering', 'cmd' );
 		$filter_order_Dir_files	= $app->getUserStateFromRequest( $this->_context_files.'.filter_order_Dir','filter_order_Dir',	'',	'word' );
 		$search_files			= $app->getUserStateFromRequest( $this->_context_files.'.search', 'search', '', 'string' );
-		$search_files			= JString::strtolower( $search_files );
+		$search_files			= StringHelper::strtolower( $search_files );
 		
 		// build list of categories
 		$javascript 	= 'class="inputbox" size="1" onchange="document.phocadownloadfilesform.submit();"';

--- a/views/phocadownloadlinkfile/view.html.php
+++ b/views/phocadownloadlinkfile/view.html.php
@@ -10,6 +10,7 @@
  */
 defined('_JEXEC') or die();
 jimport( 'joomla.application.component.view' );
+use Joomla\String\StringHelper;
  
 class PhocaDownloadCpViewPhocaDownloadLinkFile extends JViewLegacy
 {
@@ -56,7 +57,7 @@ class PhocaDownloadCpViewPhocaDownloadLinkFile extends JViewLegacy
 		$filter_order		= $app->getUserStateFromRequest( $this->_context.'.filter_order',	'filter_order',		'a.ordering', 'cmd' );
 		$filter_order_Dir	= $app->getUserStateFromRequest( $this->_context.'.filter_order_Dir',	'filter_order_Dir',	'', 'word' );
 		$search				= $app->getUserStateFromRequest( $this->_context.'.search','search', '', 'string' );
-		$search				= JString::strtolower( $search );
+		$search				= StringHelper::strtolower( $search );
 
 		// Get data from the model
 		$items		= $this->get( 'Data');


### PR DESCRIPTION
JString has been depreciated `use Joomla\String\StringHelper;`

This PR updates the component to use the latest String package due to a B/C break in the Joomla CMS 3.5+ supporting one of the changes in PHP 7 resulting in new reserved keywords in the language.

Reference on this change requirement from the Joomla CMS
https://github.com/joomla/joomla-cms/pull/6600
